### PR TITLE
Add ws: and wss: schemes

### DIFF
--- a/views/includes/csp-src.inc.php
+++ b/views/includes/csp-src.inc.php
@@ -13,6 +13,8 @@ $origins = array(
     'mediastream' => 'mediastream:',
     'blob' => 'blob:',
     'filesystem' => 'filesystem:',
+    'ws' => 'ws:',
+    'wss' => 'wss:',
 );
  
 foreach ($origins as $k => $origin)


### PR DESCRIPTION
These schemes are used by connect-src.

References:

https://content-security-policy.com/connect-src/ (Search for WebSocket) https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#scheme-source https://developer.mozilla.org/en-US/docs/Web/URI/Schemes